### PR TITLE
[Extension] Fix LogicalName not set for BundleResource

### DIFF
--- a/tools/MonoDevelop.Figma/Extensions/ProjectExtensions.cs
+++ b/tools/MonoDevelop.Figma/Extensions/ProjectExtensions.cs
@@ -240,7 +240,7 @@ namespace MonoDevelop.Figma
 					if (!currentProject.PathExistsInProject(item))
 					{
 						var projectFile = new ProjectFile(item, BuildAction.BundleResource);
-						projectFile.Metadata.SetValue("LogicalName", projectFile.ResourceId, "");
+						projectFile.ResourceId = item.FileName;
 						currentProject.AddFile(projectFile);
 					}
 				}


### PR DESCRIPTION
Setting the ResourceId on the ProjectFile added ensures that the
LogicalName is set to be the name of the image file so it can
be used by the generated code.