### PR TITLE
[Extension] Use progress monitors

### DIFF
--- a/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Extensions/NodeExtensions.cs
+++ b/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Extensions/NodeExtensions.cs
@@ -122,7 +122,7 @@ namespace FigmaSharp.Controls.Cocoa
             var found = ControlTypeService.GetByName(name);
             if (found.Equals(default))
             {
-                Console.WriteLine("Component Key not found: {0}", name);
+                LoggingService.LogError("Component Key not found: {0}", name);
                 return FigmaControlType.NotDefined;
             }
             return found.nativeControlType;
@@ -133,7 +133,7 @@ namespace FigmaSharp.Controls.Cocoa
             var found = ControlTypeService.GetByName(name);
             if (found.Equals(default))
             {
-                Console.WriteLine("Component Key not found: {0}", name);
+                LoggingService.LogError("Component Key not found: {0}", name);
                 return NativeControlVariant.NotDefined;
             }
             return found.nativeControlVariant;
@@ -301,7 +301,7 @@ namespace FigmaSharp.Controls.Cocoa
         //            return found.nativeControlComponentType;
         //        }
 
-        //        Console.WriteLine ("Component Key not found: {0} - {1}", figmaInstance.Component.key, figmaInstance.Component.name);
+        //        LoggingService.LogError (string.Format("Component Key not found: {0} - {1}", figmaInstance.Component.key, figmaInstance.Component.name));
         //        //throw new KeyNotFoundException(figmaInstance.Component.key);
         //    }
         //    return NativeControlComponentType.NotDefined;

--- a/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Extensions/NodeExtensions.cs
+++ b/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Extensions/NodeExtensions.cs
@@ -122,7 +122,7 @@ namespace FigmaSharp.Controls.Cocoa
             var found = ControlTypeService.GetByName(name);
             if (found.Equals(default))
             {
-                LoggingService.LogError("Component Key not found: {0}", name);
+                LoggingService.LogWarning("Component Key not found: {0}", name);
                 return FigmaControlType.NotDefined;
             }
             return found.nativeControlType;
@@ -133,7 +133,7 @@ namespace FigmaSharp.Controls.Cocoa
             var found = ControlTypeService.GetByName(name);
             if (found.Equals(default))
             {
-                LoggingService.LogError("Component Key not found: {0}", name);
+                LoggingService.LogWarning("Component Key not found: {0}", name);
                 return NativeControlVariant.NotDefined;
             }
             return found.nativeControlVariant;

--- a/FigmaSharp.Controls/FigmaSharp.Controls/FigmaPackage/FigmaBundle.cs
+++ b/FigmaSharp.Controls/FigmaSharp.Controls/FigmaPackage/FigmaBundle.cs
@@ -146,7 +146,7 @@ namespace FigmaSharp
 			if (Version == null) {
 				Version = new FigmaFileVersion() { id = Manifest.DocumentVersion };
 			}
-			Console.WriteLine($"[Done] Refreshed Figma Package from remote Figma API");
+			LoggingService.LogInfo($"[Done] Refreshed Figma Package from remote Figma API");
 		}
 
 		//Generates the .figmafile
@@ -203,7 +203,7 @@ namespace FigmaSharp
 				bundle.Load (fullPath);
 				return bundle;
 			} catch (Exception ex) {
-				Console.WriteLine (ex);
+				LoggingService.LogError ("[FIGMA] Error", ex);
 				//not a bundle
 				return null;
 			}
@@ -242,7 +242,7 @@ namespace FigmaSharp
         //    foreach (var item in mainNodes)
         //    {
         //        GenerateFigmaFile(item);
-        //        Console.WriteLine($"[Done] Generated '{item.name}' file");
+        //        LoggingService.LogInfo($"[Done] Generated '{item.name}' file");
         //    }
         //}
 
@@ -254,7 +254,7 @@ namespace FigmaSharp
         //	var mainNodes = figmaFileProvider.GetMainLayers();
         //	foreach (var item in mainNodes) {
         //		GenerateFigmaFile (item);
-        //		Console.WriteLine($"[Done] Generated '{item.name}' file");
+        //		LoggingService.LogInfo($"[Done] Generated '{item.name}' file");
         //	}
         //}
 
@@ -264,7 +264,7 @@ namespace FigmaSharp
         //	if (figmaFileView != null) {
         //		Views.Add(figmaFileView);
         //	} else {
-        //		Console.WriteLine("Cannot generate a file for '{0}': Invalid ClassName. Skipping...", figmaNode.name);
+        //		LoggingService.LogInfo("Cannot generate a file for '{0}': Invalid ClassName. Skipping...", figmaNode.name);
         //	}
         //}
 
@@ -320,7 +320,7 @@ namespace FigmaSharp
 			SaveLocalDocument (includeImages, provider);
 			//if (createViews)
 			//	SaveViews (codeRendererService, writePublicClassIfExists, translateLabels: translateLabels);
-			Console.WriteLine ($"[Done] Saved all the files from Figma Package");
+			LoggingService.LogInfo($"[Done] Saved all the files from Figma Package");
 		}
 
 		#endregion

--- a/FigmaSharp.Views/FigmaSharp.Views.Cocoa/Graphics/PathBuilder.cs
+++ b/FigmaSharp.Views/FigmaSharp.Views.Cocoa/Graphics/PathBuilder.cs
@@ -29,6 +29,7 @@ using System.Text;
 using System.Globalization;
 
 using CoreGraphics;
+using FigmaSharp.Services;
 
 namespace FigmaSharp.Views.Cocoa.Graphics
 {
@@ -265,7 +266,7 @@ namespace FigmaSharp.Views.Cocoa.Graphics
 				}
 				else
 				{
-					Console.WriteLine("Don't know how to handle the path command: " + command);
+					LoggingService.LogError("Don't know how to handle the path command: " + command);
 				}
 			}
 			else
@@ -350,7 +351,7 @@ namespace FigmaSharp.Views.Cocoa.Graphics
 			}
 			else
 			{
-				Console.WriteLine("Don't know how to handle the path command: " + command);
+				LoggingService.LogWarning("Don't know how to handle the path command: " + command);
 			}
 
 			if (!(command == 'C' || command == 'c' || command == 's' || command == 'S'))

--- a/FigmaSharp.Views/FigmaSharp.Views.Cocoa/Graphics/XExtensions.cs
+++ b/FigmaSharp.Views/FigmaSharp.Views.Cocoa/Graphics/XExtensions.cs
@@ -27,6 +27,7 @@ using System.Globalization;
 using System.Xml.Linq;
 
 using AppKit;
+using FigmaSharp.Services;
 
 namespace FigmaSharp.Views.Cocoa.Graphics
 {
@@ -110,7 +111,7 @@ namespace FigmaSharp.Views.Cocoa.Graphics
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex);
+                LoggingService.LogError("[FIGMA] Error.", ex);
             }
           
             return NSColor.Clear;

--- a/FigmaSharp.Views/FigmaSharp.Views.Cocoa/ViewWrappers/SvgView.cs
+++ b/FigmaSharp.Views/FigmaSharp.Views.Cocoa/ViewWrappers/SvgView.cs
@@ -23,6 +23,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
+using FigmaSharp.Services;
 using FigmaSharp.Views.Cocoa.Graphics;
 
 namespace FigmaSharp.Views.Cocoa
@@ -32,7 +33,7 @@ namespace FigmaSharp.Views.Cocoa
         public void Load(string image)
         {
             ((SvgNSView)nativeView).Load(image);
-            Console.WriteLine(image);
+            LoggingService.LogInfo(image);
         }
 
         public SvgView() : base (new SvgNSView ())

--- a/FigmaSharp.Views/FigmaSharp.Views.Cocoa/ViewsHelper.cs
+++ b/FigmaSharp.Views/FigmaSharp.Views.Cocoa/ViewsHelper.cs
@@ -26,7 +26,7 @@ using System;
 using System.Reflection;
 
 using AppKit;
-
+using FigmaSharp.Services;
 using FigmaSharp.Views.Native.Cocoa;
 
 namespace FigmaSharp.Views.Cocoa
@@ -79,10 +79,9 @@ namespace FigmaSharp.Views.Cocoa
 					return NSImage.FromStream (stream);
 				}
 			} catch (System.ArgumentNullException) {
-				Console.WriteLine ("[ERROR] File '{0}' not found in Resources and/or not set Build action to EmbeddedResource", resource);
+				LoggingService.LogError(string.Format("[FIGMA]  File '{0}' not found in Resources and/or not set Build action to EmbeddedResource", resource));
 			} catch (System.Exception ex) {
-				Console.WriteLine (ex);
-
+				LoggingService.LogError("[FIGMA] Error.", ex);
 			}
 			return null;
 		}

--- a/FigmaSharp/FigmaSharp.Cocoa/Converters/Layers/FrameConverter.cs
+++ b/FigmaSharp/FigmaSharp.Cocoa/Converters/Layers/FrameConverter.cs
@@ -65,7 +65,7 @@ namespace FigmaSharp.Cocoa.Converters
                             currengroupView.Layer.BackgroundColor = fill.color.ToCGColor ();
                         }
                     } else {
-                        Console.WriteLine ($"NOT IMPLEMENTED FILL : {fill.type}");
+                        LoggingService.LogWarning ($"NOT IMPLEMENTED FILL : {fill.type}");
 					}
                     //currengroupView.Layer.Hidden = !fill.visible;
                 }

--- a/FigmaSharp/FigmaSharp.Cocoa/Converters/Layers/RectangleVectorConverter.cs
+++ b/FigmaSharp/FigmaSharp.Cocoa/Converters/Layers/RectangleVectorConverter.cs
@@ -62,7 +62,7 @@ namespace FigmaSharp.Cocoa.Converters
                             currengroupView.Layer.BackgroundColor = fill.color.ToCGColor (fill.opacity);
                         }
                     } else {
-                        Console.WriteLine ($"NOT IMPLEMENTED FILL : {fill.type}");
+                        LoggingService.LogWarning ($"NOT IMPLEMENTED FILL : {fill.type}");
                     }
                 }
             }

--- a/FigmaSharp/FigmaSharp.Cocoa/Converters/Layers/VectorConverter.cs
+++ b/FigmaSharp/FigmaSharp.Cocoa/Converters/Layers/VectorConverter.cs
@@ -56,7 +56,7 @@ namespace FigmaSharp.Cocoa.Converters
                             //currengroupView.Layer.BackgroundColor = fill.color.ToCGColor ();
                         }
                     } else {
-                        Console.WriteLine ($"NOT IMPLEMENTED FILL : {fill.type}");
+                        LoggingService.LogWarning($"NOT IMPLEMENTED FILL : {fill.type}");
                     }
                     //currengroupView.Layer.Hidden = !fill.visible;
                 }

--- a/FigmaSharp/FigmaSharp.Cocoa/Converters/TextConverter.cs
+++ b/FigmaSharp/FigmaSharp.Cocoa/Converters/TextConverter.cs
@@ -39,7 +39,7 @@ namespace FigmaSharp.Cocoa.Converters
         public override IView ConvertToView (FigmaNode currentNode, ViewNode parent, ViewRenderService rendererService)
         {
             var figmaText = ((FigmaText)currentNode);
-            Console.WriteLine("'{0}' with Font:'{1}({2})' s:{3} w:{4} ...", figmaText.characters, figmaText.style.fontFamily, figmaText.style.fontPostScriptName, figmaText.style.fontSize, figmaText.style.fontWeight);
+            LoggingService.LogInfo("'{0}' with Font:'{1}({2})' s:{3} w:{4} ...", figmaText.characters, figmaText.style.fontFamily, figmaText.style.fontPostScriptName, figmaText.style.fontSize, figmaText.style.fontWeight);
             var label = new Label();
 			var textField = label.NativeObject as FNSTextField;
 			textField.Font = figmaText.style.ToNSFont();

--- a/FigmaSharp/FigmaSharp.Cocoa/Extensions/FigmaExtensions.cs
+++ b/FigmaSharp/FigmaSharp.Cocoa/Extensions/FigmaExtensions.cs
@@ -34,6 +34,7 @@ using Foundation;
 
 using FigmaSharp.Models;
 using FigmaSharp.Cocoa.Helpers;
+using FigmaSharp.Services;
 
 namespace FigmaSharp.Cocoa
 {
@@ -217,8 +218,8 @@ namespace FigmaSharp.Cocoa
                     font = NSFont.SystemFontOfSize (style.fontSize, GetFontWeight (style));
 
             } catch (Exception ex) {
-                Console.WriteLine ($"Font not found in system: {family} .. using system default font.");
-                Console.WriteLine (ex);
+                LoggingService.LogInfo ($"Font not found in system: {family} .. using system default font.");
+                LoggingService.LogError ("[FIGMA] Error", ex);
                 font = NSFont.SystemFontOfSize (style.fontSize, GetFontWeight (style));
             }
 
@@ -226,7 +227,7 @@ namespace FigmaSharp.Cocoa
 
             //if (FontConversion.TryGetValue (family, out string newFamilyName))
             //{
-            //    Console.WriteLine("{0} font was in the conversion dicctionary and was replaced by {1}.", family, newFamilyName);
+            //    LoggingService.LogInfo("{0} font was in the conversion dicctionary and was replaced by {1}.", family, newFamilyName);
             //    family = newFamilyName;
             //}
 
@@ -241,7 +242,7 @@ namespace FigmaSharp.Cocoa
             //}
             //catch (Exception ex)
             //{
-            //    Console.WriteLine(ex);
+            //    LoggingService.LogError("[FIGMA] Error", ex);
             //}
 
             //if (font == null)
@@ -252,10 +253,10 @@ namespace FigmaSharp.Cocoa
             //    }
             //    catch (Exception ex)
             //    {
-            //        Console.WriteLine(ex);
+            //        LoggingService.LogError("[FIGMA] Error", ex);
             //    }
             //}
-           // return font;
+            // return font;
         }
 
         public static CGPoint GetRelativePosition(this IAbsoluteBoundingBox parent, IAbsoluteBoundingBox node)

--- a/FigmaSharp/FigmaSharp/Converters/NodeConverter.cs
+++ b/FigmaSharp/FigmaSharp/Converters/NodeConverter.cs
@@ -54,7 +54,7 @@ namespace FigmaSharp.Converters
 					}
 				}
 			} catch (System.Exception ex) {
-				Console.WriteLine (ex);
+				LoggingService.LogError("[FIGMA] Error", ex);
 
 			}
 			return default (T);
@@ -69,7 +69,7 @@ namespace FigmaSharp.Converters
 				foreach (var property in properties) {
 					var data = property.Split (':');
 					if (data.Length != 2) {
-						Console.WriteLine ($"Error format in parameter: '{property}'");
+						LoggingService.LogError ($"Error format in parameter: '{property}'");
 						continue;
 					}
 					ids.Add (data[0], data[1]);

--- a/FigmaSharp/FigmaSharp/FigmaFile/FigmaFile.cs
+++ b/FigmaSharp/FigmaSharp/FigmaFile/FigmaFile.cs
@@ -92,7 +92,7 @@ namespace FigmaSharp
         /// </summary>
         public void Reload ()
         {
-            Console.WriteLine($"Loading views..");
+            LoggingService.LogInfo($"Loading views..");
             try
             {
                 FigmaImages.Clear();
@@ -106,8 +106,7 @@ namespace FigmaSharp
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Error reading resource");
-                Console.WriteLine(ex);
+                LoggingService.LogError($"[FIGMA.FILE] Error reading resource", ex);
             }
         }
 

--- a/FigmaSharp/FigmaSharp/Helpers/WebApiHelper.cs
+++ b/FigmaSharp/FigmaSharp/Helpers/WebApiHelper.cs
@@ -28,7 +28,7 @@ using System.Linq;
 using System.Reflection;
 
 using FigmaSharp.Models;
-
+using FigmaSharp.Services;
 using Newtonsoft.Json;
 
 namespace FigmaSharp.Helpers
@@ -84,7 +84,7 @@ namespace FigmaSharp.Helpers
                 {
                     if (stream == null)
                     {
-                        Console.WriteLine("Resource '{0}' not found in assembly '{1}'", resource, assembly.FullName);
+                        LoggingService.LogWarning("Resource '{0}' not found in assembly '{1}'", resource, assembly.FullName);
                         return null;
                     }
                     using (TextReader tr = new StreamReader(stream))
@@ -95,7 +95,7 @@ namespace FigmaSharp.Helpers
             }
             catch (System.Exception ex)
             {
-                Console.WriteLine("Cannot read resource '{0}' in assembly '{1}'", resource, ex);
+                LoggingService.LogError(string.Format("[FIGMA] Cannot read resource '{0}' in assembly '{1}'", resource), ex);
                 return null;
             }
         }
@@ -122,7 +122,7 @@ namespace FigmaSharp.Helpers
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex);
+                LoggingService.LogError("[FIGMA] Error.", ex);
             }
             return string.Empty;
         }

--- a/FigmaSharp/FigmaSharp/Services/LoggingService.cs
+++ b/FigmaSharp/FigmaSharp/Services/LoggingService.cs
@@ -1,0 +1,135 @@
+﻿// Authors:
+//   Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (C) 2021 Microsoft, Corp
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Text;
+
+namespace FigmaSharp.Services
+{
+    public enum LogLevel
+    {
+        Fatal = 1,
+        Error = 2,
+        Warn = 4,
+        Info = 8,
+        Debug = 16,
+    }
+
+    public interface ILogger
+    {
+        void Log(LogLevel level, string message);
+    }
+
+    public static class LoggingService
+    {
+        static ILogger logger = new DefaultLogger();
+
+        public static void RegisterDefaultLogger(ILogger logger)
+        {
+            LoggingService.logger = logger;
+        }
+
+        public static void LogInfo(string message)
+        {
+            logger.Log(LogLevel.Info, message);
+        }
+
+        public static void LogInfo(string format, object arg0)
+        {
+            logger.Log(LogLevel.Info, string.Format(format, arg0));
+        }
+
+        public static void LogInfo(string format, object arg0, object arg1)
+        {
+            logger.Log(LogLevel.Info, string.Format(format, arg0, arg1));
+        }
+
+        public static void LogInfo(string format, object arg0, object arg1, object arg2)
+        {
+            logger.Log(LogLevel.Info, string.Format(format, arg0, arg1, arg2));
+        }
+
+        public static void LogInfo(string format, params object[] args)
+        {
+            logger.Log(LogLevel.Info, string.Format(format, args));
+        }
+
+        public static void LogError(string message)
+        {
+            logger.Log(LogLevel.Error, message);
+        }
+
+        public static void LogError(string format, object arg0)
+        {
+            logger.Log(LogLevel.Error, string.Format(format, arg0));
+        }
+
+        public static void LogError(string message, Exception ex)
+        {
+            if (ex == null)
+            {
+                logger.Log(LogLevel.Error, message);
+            }
+            else
+            {
+                var exceptionText = new StringBuilder();
+                exceptionText.AppendLine(message);
+                exceptionText.Append(ex);
+
+                logger.Log(LogLevel.Error, exceptionText.ToString());
+            }
+        }
+
+        public static void LogWarning(string message)
+        {
+            logger.Log(LogLevel.Warn, message);
+        }
+
+        public static void LogWarning(string format, object arg0)
+        {
+            logger.Log(LogLevel.Warn, string.Format(format, arg0));
+        }
+
+        public static void LogWarning(string format, object arg0, object arg1)
+        {
+            logger.Log(LogLevel.Warn, string.Format(format, arg0, arg1));
+        }
+
+        class DefaultLogger : ILogger
+        {
+            public void Log(LogLevel level, string message)
+            {
+                switch (level)
+                {
+                    case LogLevel.Info:
+                        Console.WriteLine(message);
+                        break;
+                    default:
+                        Console.WriteLine("{0}: {1}", level.ToString().ToUpper(), message);
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/FigmaSharp/FigmaSharp/Services/ModuleService.cs
+++ b/FigmaSharp/FigmaSharp/Services/ModuleService.cs
@@ -74,10 +74,10 @@ namespace FigmaSharp.Services
 
         public static void LoadModules (string directory)
         {
-            Console.WriteLine("Loading all directory modules from {0}", directory);
+            LoggingService.LogInfo("Loading all directory modules from {0}", directory);
             if (!Directory.Exists(directory))
             {
-                Console.WriteLine("[{0}] Error. Directory not found.", directory);
+                LoggingService.LogError("[{0}] Error. Directory not found.", directory);
                 return;
             }
 
@@ -89,28 +89,28 @@ namespace FigmaSharp.Services
 
         public static void LoadModuleDirectory (string directory)
         {
-            Console.WriteLine("Loading module directory: {0}", directory);
+            LoggingService.LogInfo("Loading module directory: {0}", directory);
 
             if (!Directory.Exists(directory))
             {
-                Console.WriteLine("[{0}] Error. Directory not found.", directory);
+                LoggingService.LogError("[{0}] Error. Directory not found.", directory);
                 return;
             }
 
             var manifestFilePath = Path.Combine(directory, "figma.manifest");
             if (!File.Exists(manifestFilePath))
             {
-                Console.WriteLine("Error figma.manifest not found in directory '{0}'", directory);
+                LoggingService.LogError("Error figma.manifest not found in directory '{0}'", directory);
                 return;
             }
 
-            Console.WriteLine("Loading figma.manifest in {0} ...", manifestFilePath);
+            LoggingService.LogInfo("Loading figma.manifest in {0} ...", manifestFilePath);
 
             var file = File.ReadAllText (manifestFilePath);
             var manifest = JsonConvert.DeserializeObject<FigmaAssemblyManifest>(file);
 
-            Console.WriteLine("Version: {0}", manifest.version);
-            Console.WriteLine("Platform: {0}", manifest.platform);
+            LoggingService.LogInfo("Version: {0}", manifest.version);
+            LoggingService.LogInfo("Platform: {0}", manifest.platform);
 
             var enumeratedFiles = Directory.EnumerateFiles(directory, "*.dll").ToArray();
             LoadModule(manifest.platform, enumeratedFiles);
@@ -120,18 +120,18 @@ namespace FigmaSharp.Services
         {
             Dictionary<Assembly, string> instanciableTypes = new Dictionary<Assembly, string>();
 
-            Console.WriteLine("Loading {0}...", string.Join(",", filePaths));
+            LoggingService.LogInfo("Loading {0}...", string.Join(",", filePaths));
 
             foreach (var file in filePaths)
             {
                 if (!File.Exists (file))
                 {
-                    Console.WriteLine("[{0}] Error. File not found.", file);
+                    LoggingService.LogError("[{0}] Error. File not found.", file);
                     continue;
                 }
 
                 var fileName = Path.GetFileName(file);
-                Console.WriteLine("[{0}] Found.", fileName);
+                LoggingService.LogInfo("[{0}] Found.", fileName);
                 try
                 {
                     var assembly = Assembly.LoadFile(file);
@@ -139,7 +139,7 @@ namespace FigmaSharp.Services
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine("[{0}] Error loading: {1}", fileName, ex);
+                    LoggingService.LogError(string.Format("[{0}] Error loading", fileName), ex);
                 }
             }
 
@@ -150,7 +150,7 @@ namespace FigmaSharp.Services
                 ProcessCodePositionConverters (assemblyTypes.Key, platform);
             }
 
-            Console.WriteLine("[{0}] Finished.");
+            LoggingService.LogInfo("Finished.");
         }
 
         public static void ProcessConverters (Assembly assembly, string platform)
@@ -166,10 +166,10 @@ namespace FigmaSharp.Services
                 {
                     if (type.GetTypeInfo().IsAbstract)
                     {
-                        Console.WriteLine("[{0}] Skipping {1} (abstract class).", assembly, type);
+                        LoggingService.LogInfo("[{0}] Skipping {1} (abstract class).", assembly, type);
                         continue;
                     }
-                    Console.WriteLine("[{0}] Creating instance {1}...", assembly, type);
+                    LoggingService.LogInfo("[{0}] Creating instance {1}...", assembly, type);
                     try
                     {
                         if (Activator.CreateInstance(type) is NodeConverter element)
@@ -177,14 +177,14 @@ namespace FigmaSharp.Services
                     }
                     catch (Exception ex)
                     {
-                        Console.WriteLine(ex);
+                        LoggingService.LogError("[FIGMA] Error", ex);
                     }
-                    Console.WriteLine("[{0}] Loaded.", type);
+                    LoggingService.LogInfo("[{0}] Loaded.", type);
                 }
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex);
+                LoggingService.LogError("[FIGMA] Error", ex);
             }
         }
 
@@ -201,7 +201,7 @@ namespace FigmaSharp.Services
                 {
                     if (type.GetTypeInfo().IsAbstract)
                     {
-                        Console.WriteLine("[{0}] Skipping {1} (abstract class).", assembly, type);
+                        LoggingService.LogInfo("[{0}] Skipping {1} (abstract class).", assembly, type);
                         continue;
                     }
                     Console.WriteLine("[{0}] Creating instance {1}...", assembly, type);
@@ -212,14 +212,14 @@ namespace FigmaSharp.Services
                     }
                     catch (Exception ex)
                     {
-                        Console.WriteLine(ex);
+                        LoggingService.LogError("[FIGMA] Error", ex);
                     }
-                    Console.WriteLine("[{0}] Loaded.", type);
+                    LoggingService.LogInfo("[{0}] Loaded.", type);
                 }
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex);
+                LoggingService.LogError("[FIGMA] Error", ex);
             }
         }
 
@@ -236,7 +236,7 @@ namespace FigmaSharp.Services
                 {
                     if (type.GetTypeInfo().IsAbstract)
                     {
-                        Console.WriteLine("[{0}] Skipping {1} (abstract class).", assembly, type);
+                        LoggingService.LogInfo("[{0}] Skipping {1} (abstract class).", assembly, type);
                         continue;
                     }
                     Console.WriteLine("[{0}] Creating instance {1}...", assembly, type);
@@ -247,14 +247,14 @@ namespace FigmaSharp.Services
                     }
                     catch (Exception ex)
                     {
-                        Console.WriteLine(ex);
+                        LoggingService.LogError("[FIGMA] Error", ex);
                     }
-                    Console.WriteLine("[{0}] Loaded.", type);
+                    LoggingService.LogInfo("[{0}] Loaded.", type);
                 }
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex);
+                LoggingService.LogError("[FIGMA] Error", ex);
             }
         }
 

--- a/FigmaSharp/FigmaSharp/Services/Providers/AssemblyResourceNodeProvider.cs
+++ b/FigmaSharp/FigmaSharp/Services/Providers/AssemblyResourceNodeProvider.cs
@@ -48,7 +48,7 @@ namespace FigmaSharp.Services
 
         public override void OnStartImageLinkProcessing(List<ViewNode> imageFigmaNodes)
         {
-            Console.WriteLine($"Loading images..");
+            LoggingService.LogInfo($"Loading images..");
 
             if (imageFigmaNodes.Count > 0)
             {
@@ -63,7 +63,7 @@ namespace FigmaSharp.Services
                 }
             }
 
-            Console.WriteLine("Ended image link processing");
+            LoggingService.LogInfo("Ended image link processing");
             OnImageLinkProcessed();
         }
     }

--- a/FigmaSharp/FigmaSharp/Services/Providers/FileNodeProvider.cs
+++ b/FigmaSharp/FigmaSharp/Services/Providers/FileNodeProvider.cs
@@ -50,7 +50,7 @@ namespace FigmaSharp.Services
         public override void OnStartImageLinkProcessing(List<ViewNode> imageFigmaNodes)
         {
             //not needed in local files
-            Console.WriteLine($"Loading images..");
+            LoggingService.LogInfo($"Loading images..");
 
             if (imageFigmaNodes.Count > 0)
             {
@@ -74,16 +74,16 @@ namespace FigmaSharp.Services
                     }
                     catch (FileNotFoundException ex)
                     {
-                        Console.WriteLine("[FIGMA.RENDERER] Resource '{0}' not found.", ex.Message);
+                        LoggingService.LogError("[FIGMA.RENDERER] Resource '{0}' not found.", ex);
                     }
                     catch (Exception ex)
                     {
-                        Console.WriteLine(ex);
+                        LoggingService.LogError("[FIGMA.RENDERER] Error.", ex);
                     }
                 }
             }
 
-            Console.WriteLine("Ended image link processing");
+            LoggingService.LogInfo("Ended image link processing");
             OnImageLinkProcessed();
         }
     }

--- a/FigmaSharp/FigmaSharp/Services/Providers/NodeProvider.cs
+++ b/FigmaSharp/FigmaSharp/Services/Providers/NodeProvider.cs
@@ -70,14 +70,11 @@ namespace FigmaSharp.Services
 					ProcessNodeRecursively (item, null);
 			} catch (System.Net.WebException ex) {
 				if (!AppContext.Current.IsApiConfigured)
-					Console.Error.WriteLine ($"Cannot connect to Figma server: TOKEN not configured.");
+					LoggingService.LogError ($"Cannot connect to Figma server: TOKEN not configured.", ex);
 				else
-					Console.Error.WriteLine ($"Cannot connect to Figma server: wrong TOKEN?");
-
-				Console.WriteLine (ex);
+					LoggingService.LogError ($"Cannot connect to Figma server: wrong TOKEN?", ex);
 			} catch (Exception ex) {
-				Console.WriteLine ($"Error reading remote resources. Ensure you added NewtonSoft nuget or cannot parse the to json?");
-				Console.WriteLine (ex);
+				LoggingService.LogError ($"Error reading remote resources. Ensure you added NewtonSoft nuget or cannot parse the to json?", ex);
 			}
 		}
 
@@ -237,7 +234,7 @@ namespace FigmaSharp.Services
 					}
 					catch (Exception ex)
 					{
-						Console.WriteLine(ex);
+						LoggingService.LogError("[FIGMA] Error.", ex);
 					}
 				}
 			};

--- a/FigmaSharp/FigmaSharp/Services/Providers/RemoteNodeProvider.cs
+++ b/FigmaSharp/FigmaSharp/Services/Providers/RemoteNodeProvider.cs
@@ -62,13 +62,13 @@ namespace FigmaSharp.Services
 
                 //var imageCache = new Dictionary<string, List<string>>();
                 List<Tuple<string, List<string>>> imageCacheResponse = new List<Tuple<string, List<string>>>();
-                Console.WriteLine("Detected a total of {0} possible {1} images.  ", totalImages, imageFormat);
+                LoggingService.LogInfo("Detected a total of {0} possible {1} images.  ", totalImages, imageFormat);
 
                 var images = new List<string>();
                 for (int i = 0; i < numberLoop; i++)
                 {
                     var vectors = imageFigmaNodes.Skip(i * CallNumber).Take(CallNumber);
-                    Console.WriteLine("[{0}/{1}] Processing Images ... {2} ", i, numberLoop, vectors.Count());
+                    LoggingService.LogInfo("[{0}/{1}] Processing Images ... {2} ", i, numberLoop, vectors.Count());
                     var ids = vectors.Select(s => CreateEmptyImageNodeRequest(s.Node))
                         .ToArray();
 
@@ -96,7 +96,7 @@ namespace FigmaSharp.Services
                 }
 
                 //get images not dupplicates
-                Console.WriteLine("Finished image to download {0}", images.Count);
+                LoggingService.LogInfo("Finished image to download {0}", images.Count);
 
                 if (imageFormat == ImageFormat.svg)
                 {
@@ -109,7 +109,7 @@ namespace FigmaSharp.Services
                         foreach (var figmaNodeId in imageUrl.Item2)
                         {
                             var vector = imageFigmaNodes.FirstOrDefault(s => s.Node.id == figmaNodeId);
-                            Console.Write("[{0}:{1}:{2}] {3}...", vector.Node.GetType(), vector.Node.id, vector.Node.name, imageUrl);
+                            LoggingService.LogInfo("[{0}:{1}:{2}] {3}...", vector.Node.GetType(), vector.Node.id, vector.Node.name, imageUrl);
 
                             if (vector != null && vector.View is ISvgView imageView)
                             {
@@ -118,7 +118,7 @@ namespace FigmaSharp.Services
                                     imageView.Load(image);
                                 });
                             }
-                            Console.Write("OK \n");
+                            LoggingService.LogInfo("OK \n");
                         }
                     }
                 }
@@ -131,7 +131,7 @@ namespace FigmaSharp.Services
                         foreach (var figmaNodeId in imageUrl.Item2)
                         {
                             var vector = imageFigmaNodes.FirstOrDefault(s => s.Node.id == figmaNodeId);
-                            Console.WriteLine("[{0}:{1}:{2}] {3}...", vector.Node.GetType(), vector.Node.id, vector.Node.name, imageUrl);
+                            LoggingService.LogInfo("[{0}:{1}:{2}] {3}...", vector.Node.GetType(), vector.Node.id, vector.Node.name, imageUrl);
 
                             if (vector != null)
                             {
@@ -147,18 +147,18 @@ namespace FigmaSharp.Services
                                     }
                                     else
                                     {
-                                        Console.WriteLine("[{0}:{1}:{2}] Error cannot assign the image to the current view {3}", vector.Node.GetType(), vector.Node.id, vector.Node.name, vector.View.GetType().FullName);
+                                        LoggingService.LogInfo("[{0}:{1}:{2}] Error cannot assign the image to the current view {3}", vector.Node.GetType(), vector.Node.id, vector.Node.name, vector.View.GetType().FullName);
                                     }
                                 });
                             }
-                            Console.Write("OK \n");
+                            LoggingService.LogInfo("OK \n");
                         }
                     }
                 }
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex);
+                LoggingService.LogError("[FIGMA] Error.", ex);
             }
         }
 

--- a/FigmaSharp/FigmaSharp/Services/ViewRenderService.cs
+++ b/FigmaSharp/FigmaSharp/Services/ViewRenderService.cs
@@ -122,18 +122,17 @@ namespace FigmaSharp.Services
                     nodeProvider.OnStartImageLinkProcessing(ImageVectors);
                 }
 
-                Console.WriteLine("View generation finished.");
+                LoggingService.LogInfo("View generation finished.");
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Error reading resource");
-                Console.WriteLine(ex);
+                LoggingService.LogError("Error reading resource" , ex);
             }
         }
 
         private void FileProvider_ImageLinksProcessed(object sender, EventArgs e)
         {
-            Console.WriteLine($"Image Links ended.");
+            LoggingService.LogInfo($"Image Links ended.");
         }
 
         public void Refresh(ViewRenderServiceOptions options)
@@ -144,7 +143,7 @@ namespace FigmaSharp.Services
 
             SetOptions(options);
 
-            Console.WriteLine($"Reading successfull");
+            LoggingService.LogInfo($"Reading successfull");
 
             FigmaCanvas canvas;
             if (options.StartPage >= 0 && options.StartPage <= nodeProvider.Response.document.children.Length)
@@ -345,7 +344,7 @@ namespace FigmaSharp.Services
             {
                 if (child.View == null)
                 {
-                    Console.WriteLine("Node {0} has no view to process... skipping", child.Node);
+                    LoggingService.LogInfo("Node {0} has no view to process... skipping", child.Node);
                     continue;
                 }
 
@@ -387,8 +386,8 @@ namespace FigmaSharp.Services
                 options = new ViewRenderServiceOptions();
             }
 
-            Console.WriteLine("[FigmaViewRenderer] Starting process..");
-            Console.WriteLine($"Reading {figmaName} from resources..");
+            LoggingService.LogInfo("[FigmaViewRenderer] Starting process..");
+            LoggingService.LogInfo($"Reading {figmaName} from resources..");
 
             this.container = container;
 
@@ -410,8 +409,7 @@ namespace FigmaSharp.Services
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Error reading resource");
-                Console.WriteLine(ex);
+                LoggingService.LogError("[FIGMA] Error reading resource", ex);
             }
         }
 
@@ -421,8 +419,8 @@ namespace FigmaSharp.Services
                 options = new ViewRenderServiceOptions();
             }
 
-            Console.WriteLine("[FigmaViewRenderer] Starting process..");
-            Console.WriteLine($"Reading {figmaName} from resources..");
+            LoggingService.LogInfo("[FigmaViewRenderer] Starting process..");
+            LoggingService.LogInfo($"Reading {figmaName} from resources..");
 
             this.container = container;
 
@@ -442,18 +440,17 @@ namespace FigmaSharp.Services
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Error reading resource");
-                Console.WriteLine(ex);
+                LoggingService.LogError("[FIGMA] Error reading resource.", ex);
             }
         }
 
         //TODO: This 
         protected void GenerateViewsRecursively(FigmaNode currentNode, ViewNode parent, ViewRenderServiceOptions options)
         {
-            Console.WriteLine("[{0}.{1}] Processing {2}..", currentNode?.id, currentNode?.name, currentNode?.GetType());
+            LoggingService.LogInfo("[{0}.{1}] Processing {2}..", currentNode?.id, currentNode?.name, currentNode?.GetType());
 
             //if (currentNode.name.StartsWith ("#") || currentNode.name.StartsWith ("//")) {
-            //    Console.WriteLine ("[{0}.{1}] Detected skipped flag in name.. Skipping...", currentNode?.id, currentNode?.name, currentNode?.GetType ());
+            //    LoggingService.LogInfo ("[{0}.{1}] Detected skipped flag in name.. Skipping...", currentNode?.id, currentNode?.name, currentNode?.GetType ());
             //    return;
             //}
 
@@ -471,7 +468,7 @@ namespace FigmaSharp.Services
             }
             else
             {
-                Console.WriteLine("[{1}.{2}] There is no Converter for this type: {0}", currentNode.GetType(), currentNode.id, currentNode.name);
+                LoggingService.LogInfo("[{1}.{2}] There is no Converter for this type: {0}", currentNode.GetType(), currentNode.id, currentNode.name);
             }
 
             if (NodeScansChildren(currentNode, converter, options))

--- a/tools/FigmaSharp.Designer/BorderedWindow.cs
+++ b/tools/FigmaSharp.Designer/BorderedWindow.cs
@@ -26,7 +26,7 @@ using System;
 
 using AppKit;
 using CoreGraphics;
-
+using FigmaSharp.Services;
 using FigmaSharp.Views;
 using FigmaSharp.Views.Cocoa;
 
@@ -114,7 +114,7 @@ namespace FigmaSharp.Designer
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex);
+                LoggingService.LogError("BorderedWindow.SetParentWindow error", ex);
             }
         }
 

--- a/tools/FigmaSharp.Designer/FigmaDesignerDelegate.cs
+++ b/tools/FigmaSharp.Designer/FigmaDesignerDelegate.cs
@@ -33,6 +33,7 @@ using CoreGraphics;
 using FigmaSharp.Models;
 using FigmaSharp.Views;
 using FigmaSharp.Views.Cocoa;
+using FigmaSharp.Services;
 
 namespace FigmaSharp.Designer
 {
@@ -123,7 +124,7 @@ namespace FigmaSharp.Designer
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine(ex);
+                    LoggingService.LogError("[FIGMA] Error", ex);
                 }
             }
         }
@@ -200,7 +201,7 @@ namespace FigmaSharp.Designer
                         }
                         catch (Exception ex)
                         {
-                            Console.WriteLine(ex);
+                            LoggingService.LogError("[FIGMA] Error", ex);
                         }
                     }
                 }
@@ -217,7 +218,7 @@ namespace FigmaSharp.Designer
                     }
                     catch (Exception ex)
                     {
-                        Console.WriteLine(ex);
+                        LoggingService.LogError("[FIGMA] Error", ex);
                     }
                 }
             }

--- a/tools/FigmaSharp.Designer/FigmaDesignerSession.cs
+++ b/tools/FigmaSharp.Designer/FigmaDesignerSession.cs
@@ -70,11 +70,11 @@ namespace FigmaSharp.Designer
             }
             catch (DirectoryNotFoundException ex)
             {
-                Console.WriteLine("[FIGMA.RENDERER] Resource directory not found ({0}). Images will not load", ex.Message);
+                LoggingService.LogInfo("[FIGMA.RENDERER] Resource directory not found ({0}). Images will not load", ex.Message);
             }
             catch (System.Exception ex)
             {
-                Console.WriteLine(ex);
+                LoggingService.LogError("[FIGMA.RENDERER] Error", ex);
             }
         }
 
@@ -89,11 +89,11 @@ namespace FigmaSharp.Designer
             }
             catch (DirectoryNotFoundException ex)
             {
-                Console.WriteLine("[FIGMA.RENDERER] Resource directory not found ({0}). Images will not load", ex.Message);
+                LoggingService.LogInfo("[FIGMA.RENDERER] Resource directory not found ({0}). Images will not load", ex.Message);
             }
             catch (System.Exception ex)
             {
-                Console.WriteLine(ex);
+                LoggingService.LogError("[FIGMA.RENDERER] Error", ex);
             }
         }
 
@@ -171,7 +171,7 @@ namespace FigmaSharp.Designer
                         }
                         catch (Exception ex)
                         {
-                            Console.WriteLine(ex);
+                            LoggingService.LogError("FigmaDesignerSession Error", ex);
                         }
                     }
                 }
@@ -191,7 +191,7 @@ namespace FigmaSharp.Designer
                     }
                     catch (Exception ex)
                     {
-                        Console.WriteLine(ex);
+                        LoggingService.LogError("FigmaDesignerSession Error", ex);
                     }
                 }
             }

--- a/tools/FigmaSharpApp/Helpers/FigmaLink.cs
+++ b/tools/FigmaSharpApp/Helpers/FigmaLink.cs
@@ -23,6 +23,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
+using FigmaSharp.Services;
 
 namespace FigmaSharpApp
 {
@@ -42,12 +43,12 @@ namespace FigmaSharpApp
 					if (id.Contains ("/"))
 						id = id.Substring (0, id.IndexOf ("/"));
 
-					Console.WriteLine ("FigmaLink: Parsed: {0}", id);
+					LoggingService.LogInfo ("FigmaLink: Parsed: {0}", id);
 					return id;
 				}
 
 			} catch {
-				Console.WriteLine ("FigmaLink: Could not parse: {0}", link);
+				LoggingService.LogError ("FigmaLink: Could not parse: {0}", link);
 			}
 
 			return link;

--- a/tools/FigmaSharpApp/Views/OpenLocationViewController.cs
+++ b/tools/FigmaSharpApp/Views/OpenLocationViewController.cs
@@ -28,6 +28,7 @@ using AppKit;
 using Foundation;
 
 using FigmaSharp.Cocoa;
+using FigmaSharp.Services;
 
 namespace FigmaSharpApp
 {
@@ -129,7 +130,7 @@ namespace FigmaSharpApp
 				}
 				catch (Exception ex)
 				{
-					Console.WriteLine(ex);
+					LoggingService.LogError("[FIGMA] Error.", ex);
 				}
 			}
 			PerformSegue ("OpenLocationSegue", this);

--- a/tools/MonoDevelop.Figma/.figma/ea4pU30ht61lUJXcr0TFIF/Views/FigmaPackageWindow.cs
+++ b/tools/MonoDevelop.Figma/.figma/ea4pU30ht61lUJXcr0TFIF/Views/FigmaPackageWindow.cs
@@ -87,7 +87,9 @@ namespace MonoDevelop.Figma
 
 		async Task GenerateBundle (string fileId, FigmaFileVersion version, string namesSpace, bool includeImages, bool translateLabels)
 		{
-			using var monitor = IdeApp.Workbench.ProgressMonitors.GetFigmaProgressMonitor ($"Adding package ‘{fileId}’…");
+			using var monitor = IdeApp.Workbench.ProgressMonitors.GetFigmaProgressMonitor (
+				$"Adding package ‘{fileId}’…",
+				"Package added successfully");
 
 			//we need to ask to figma server to get nodes as demmand
 			var fileProvider = new ControlRemoteNodeProvider();

--- a/tools/MonoDevelop.Figma/.figma/ea4pU30ht61lUJXcr0TFIF/Views/FigmaPackageWindow.cs
+++ b/tools/MonoDevelop.Figma/.figma/ea4pU30ht61lUJXcr0TFIF/Views/FigmaPackageWindow.cs
@@ -9,6 +9,7 @@ using FigmaSharp.Cocoa;
 using FigmaSharp.Controls.Cocoa.Services;
 using FigmaSharp.Helpers;
 using FigmaSharp.Models;
+using FigmaSharp.Services;
 using MonoDevelop.Figma.Services;
 using MonoDevelop.Ide;
 using MonoDevelop.Projects;
@@ -101,7 +102,7 @@ namespace MonoDevelop.Figma
 			});
 
 			//now we need to add to Monodevelop all the stuff
-			await currentProject.IncludeBundleAsync (currentBundle, includeImages, savesInProject: false);
+			await currentProject.IncludeBundleAsync (monitor, currentBundle, includeImages, savesInProject: false);
 
 			//to generate all layers we need a code renderer
 			var codeRendererService = new NativeViewCodeService(fileProvider) {
@@ -167,7 +168,7 @@ namespace MonoDevelop.Figma
 						.ToArray ();
 					return result;
 				} catch (Exception ex) {
-					Console.WriteLine (ex);
+					LoggingService.LogError ("[FIGMA] Error", ex);
 					return null;
 				}
 			});

--- a/tools/MonoDevelop.Figma/.figma/ea4pU30ht61lUJXcr0TFIF/Views/FigmaPackageWindow.cs
+++ b/tools/MonoDevelop.Figma/.figma/ea4pU30ht61lUJXcr0TFIF/Views/FigmaPackageWindow.cs
@@ -86,8 +86,7 @@ namespace MonoDevelop.Figma
 
 		async Task GenerateBundle (string fileId, FigmaFileVersion version, string namesSpace, bool includeImages, bool translateLabels)
 		{
-			IdeApp.Workbench.StatusBar.AutoPulse = true;
-			IdeApp.Workbench.StatusBar.BeginProgress ($"Adding package ‘{fileId}’…");
+			using var monitor = IdeApp.Workbench.ProgressMonitors.GetFigmaProgressMonitor ($"Adding package ‘{fileId}’…");
 
 			//we need to ask to figma server to get nodes as demmand
 			var fileProvider = new ControlRemoteNodeProvider();
@@ -121,9 +120,6 @@ namespace MonoDevelop.Figma
 			}
 
 			await IdeApp.ProjectOperations.SaveAsync(currentProject);
-
-			IdeApp.Workbench.StatusBar.EndProgress ();
-			IdeApp.Workbench.StatusBar.AutoPulse = false;
 		}
 
 		private void CancelButton_Activated (object sender, EventArgs e)

--- a/tools/MonoDevelop.Figma/.figma/ea4pU30ht61lUJXcr0TFIF/Views/GenerateViewsWindow.cs
+++ b/tools/MonoDevelop.Figma/.figma/ea4pU30ht61lUJXcr0TFIF/Views/GenerateViewsWindow.cs
@@ -195,10 +195,15 @@ namespace MonoDevelop.Figma
 			using var monitor = IdeApp.Workbench.ProgressMonitors.GetFigmaProgressMonitor($"Generating views…");
 
 			var selectedData = Data.Where(s => s.Value);
-			foreach (var item in selectedData)
+
+			int count = selectedData.Count();
+
+			using (var stepMonitor = monitor.BeginTask($"Generating views…", count))
 			{
-				using (var stepMonitor = IdeApp.Workbench.ProgressMonitors.GetFigmaProgressMonitor($"Generating {item.Description}…")) {
+				foreach (var item in selectedData)
+				{
 					await CreateBundleView(item.View, project, item.fileProvider, translationsCheckbox.State == NSCellStateValue.On);
+					monitor.Step(1);
 				}
 			}
 

--- a/tools/MonoDevelop.Figma/.figma/ea4pU30ht61lUJXcr0TFIF/Views/GenerateViewsWindow.cs
+++ b/tools/MonoDevelop.Figma/.figma/ea4pU30ht61lUJXcr0TFIF/Views/GenerateViewsWindow.cs
@@ -192,21 +192,18 @@ namespace MonoDevelop.Figma
 
 		private async void CreateButton_Activated(object sender, EventArgs e)
 		{
-			IdeApp.Workbench.StatusBar.AutoPulse = true;
-			IdeApp.Workbench.StatusBar.BeginProgress($"Generating views…");
+			using var monitor = IdeApp.Workbench.ProgressMonitors.GetFigmaProgressMonitor($"Generating views…");
 
 			var selectedData = Data.Where(s => s.Value);
 			foreach (var item in selectedData)
 			{
-				IdeApp.Workbench.StatusBar.ShowMessage($"Generating {item.Description}…");
-				await CreateBundleView(item.View, project, item.fileProvider, translationsCheckbox.State == NSCellStateValue.On);
+				using (var stepMonitor = IdeApp.Workbench.ProgressMonitors.GetFigmaProgressMonitor($"Generating {item.Description}…")) {
+					await CreateBundleView(item.View, project, item.fileProvider, translationsCheckbox.State == NSCellStateValue.On);
+				}
 			}
 
 			await IdeApp.ProjectOperations.SaveAsync(project);
 			project.NeedsReload = true;
-
-			IdeApp.Workbench.StatusBar.EndProgress();
-			IdeApp.Workbench.StatusBar.AutoPulse = false;
 
 			this.Close();
 		}

--- a/tools/MonoDevelop.Figma/.figma/ea4pU30ht61lUJXcr0TFIF/Views/GenerateViewsWindow.cs
+++ b/tools/MonoDevelop.Figma/.figma/ea4pU30ht61lUJXcr0TFIF/Views/GenerateViewsWindow.cs
@@ -192,7 +192,9 @@ namespace MonoDevelop.Figma
 
 		private async void CreateButton_Activated(object sender, EventArgs e)
 		{
-			using var monitor = IdeApp.Workbench.ProgressMonitors.GetFigmaProgressMonitor($"Generating views…");
+			using var monitor = IdeApp.Workbench.ProgressMonitors.GetFigmaProgressMonitor(
+				$"Generating views…",
+				"Views generated successfully");
 
 			var selectedData = Data.Where(s => s.Value);
 

--- a/tools/MonoDevelop.Figma/.figma/ea4pU30ht61lUJXcr0TFIF/Views/PackageUpdateWindow.cs
+++ b/tools/MonoDevelop.Figma/.figma/ea4pU30ht61lUJXcr0TFIF/Views/PackageUpdateWindow.cs
@@ -58,7 +58,9 @@ namespace MonoDevelop.Figma
 		{
 			PerformClose(this);
 
-			using var monitor = IdeApp.Workbench.ProgressMonitors.GetFigmaProgressMonitor($"Updating ‘{mainBundle.Manifest.DocumentTitle}’…");
+			using var monitor = IdeApp.Workbench.ProgressMonitors.GetFigmaProgressMonitor(
+				$"Updating ‘{mainBundle.Manifest.DocumentTitle}’…",
+				$"‘{mainBundle.Manifest.DocumentTitle}’ updated successfully");
 
 			//we need search current added views and regenerate them
 			var files = project.GetAllFigmaDesignerFiles()

--- a/tools/MonoDevelop.Figma/.figma/ea4pU30ht61lUJXcr0TFIF/Views/PackageUpdateWindow.cs
+++ b/tools/MonoDevelop.Figma/.figma/ea4pU30ht61lUJXcr0TFIF/Views/PackageUpdateWindow.cs
@@ -57,18 +57,14 @@ namespace MonoDevelop.Figma
 		{
 			PerformClose(this);
 
-			IdeApp.Workbench.StatusBar.BeginProgress($"Updating ‘{mainBundle.Manifest.DocumentTitle}’…");
-			IdeApp.Workbench.StatusBar.AutoPulse = true;
+			using var monitor = IdeApp.Workbench.ProgressMonitors.GetFigmaProgressMonitor($"Updating ‘{mainBundle.Manifest.DocumentTitle}’…");
 
 			//we need search current added views and regenerate them
 			var files = project.GetAllFigmaDesignerFiles()
 				.Where(s => s.TryGetFigmaPackageId(out var packageId) && packageId == mainBundle.FileId);
 
 			var version = versionMenu.GetFileVersion(versionPopUp.SelectedItem);
-			await project.UpdateFigmaFilesAsync (files, mainBundle, version, translationsCheckbox.State == AppKit.NSCellStateValue.On);
-
-			IdeApp.Workbench.StatusBar.AutoPulse = false;
-			IdeApp.Workbench.StatusBar.EndProgress();
+			await project.UpdateFigmaFilesAsync(files, mainBundle, version, translationsCheckbox.State == AppKit.NSCellStateValue.On);
 		}
 
 		static IEnumerable<FigmaBundle> GetFromFigmaDirectory (string directory)

--- a/tools/MonoDevelop.Figma/.figma/ea4pU30ht61lUJXcr0TFIF/Views/PackageUpdateWindow.cs
+++ b/tools/MonoDevelop.Figma/.figma/ea4pU30ht61lUJXcr0TFIF/Views/PackageUpdateWindow.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using FigmaSharp;
 using FigmaSharp.Cocoa;
 using FigmaSharp.Models;
+using FigmaSharp.Services;
 using MonoDevelop.Ide;
 
 namespace MonoDevelop.Figma
@@ -64,7 +65,7 @@ namespace MonoDevelop.Figma
 				.Where(s => s.TryGetFigmaPackageId(out var packageId) && packageId == mainBundle.FileId);
 
 			var version = versionMenu.GetFileVersion(versionPopUp.SelectedItem);
-			await project.UpdateFigmaFilesAsync(files, mainBundle, version, translationsCheckbox.State == AppKit.NSCellStateValue.On);
+			await project.UpdateFigmaFilesAsync(monitor, files, mainBundle, version, translationsCheckbox.State == AppKit.NSCellStateValue.On);
 		}
 
 		static IEnumerable<FigmaBundle> GetFromFigmaDirectory (string directory)

--- a/tools/MonoDevelop.Figma/.figma/ea4pU30ht61lUJXcr0TFIF/Views/PackageUpdateWindow.cs
+++ b/tools/MonoDevelop.Figma/.figma/ea4pU30ht61lUJXcr0TFIF/Views/PackageUpdateWindow.cs
@@ -112,7 +112,7 @@ namespace MonoDevelop.Figma
 						.ToArray();
 					return result;
 				} catch (Exception ex) {
-					Console.WriteLine(ex);
+					LoggingService.LogError("[FIGMA] Error.", ex);
 					return null;
 				}
 			});

--- a/tools/MonoDevelop.Figma/Commands/FigmaInitCommand.cs
+++ b/tools/MonoDevelop.Figma/Commands/FigmaInitCommand.cs
@@ -24,6 +24,7 @@
 
 using FigmaSharp.Controls.Cocoa;
 using MonoDevelop.Components.Commands;
+using MonoDevelop.Figma.Services;
 
 namespace MonoDevelop.Figma.Commands
 {
@@ -31,6 +32,7 @@ namespace MonoDevelop.Figma.Commands
     {
         protected override void Run()
         {
+            ExtensionLoggingService.Init();
             Resources.Init();
             FigmaControlsApplication.Init(FigmaRuntime.Token);
         }

--- a/tools/MonoDevelop.Figma/Commands/OpenLocalDocumentCommandHandler.cs
+++ b/tools/MonoDevelop.Figma/Commands/OpenLocalDocumentCommandHandler.cs
@@ -56,7 +56,7 @@ namespace MonoDevelop.Figma.Commands
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex);
+                LoggingService.LogError("[FIGMA] Error.", ex);
             }
             info.Visible = info.Enabled = false;
         }

--- a/tools/MonoDevelop.Figma/Commands/OpenRemoteDocumentCommand.cs
+++ b/tools/MonoDevelop.Figma/Commands/OpenRemoteDocumentCommand.cs
@@ -64,7 +64,7 @@ namespace MonoDevelop.Figma.Commands
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex);
+                LoggingService.LogError("[FIGMA] Error.", ex);
             }
             info.Visible = info.Enabled = false;
         }

--- a/tools/MonoDevelop.Figma/Commands/RegenerateDocumentCommandHandler.cs
+++ b/tools/MonoDevelop.Figma/Commands/RegenerateDocumentCommandHandler.cs
@@ -60,7 +60,9 @@ namespace MonoDevelop.Figma.Commands
                 }
                 var includeImages = true;
 
-                using var monitor = IdeApp.Workbench.ProgressMonitors.GetFigmaProgressMonitor($"Regenerating ‘{bundle.Manifest.DocumentTitle}’…");
+                using var monitor = IdeApp.Workbench.ProgressMonitors.GetFigmaProgressMonitor(
+                    $"Regenerating ‘{bundle.Manifest.DocumentTitle}’…",
+                    $"‘{bundle.Manifest.DocumentTitle}’ regenerated successfully");
 
                 await Task.Run(() =>
                 {

--- a/tools/MonoDevelop.Figma/Commands/RegenerateDocumentCommandHandler.cs
+++ b/tools/MonoDevelop.Figma/Commands/RegenerateDocumentCommandHandler.cs
@@ -60,8 +60,7 @@ namespace MonoDevelop.Figma.Commands
                 }
                 var includeImages = true;
 
-                IdeApp.Workbench.StatusBar.AutoPulse = true;
-                IdeApp.Workbench.StatusBar.BeginProgress($"Regenerating ‘{bundle.Manifest.DocumentTitle}’…");
+                using var monitor = IdeApp.Workbench.ProgressMonitors.GetFigmaProgressMonitor($"Regenerating ‘{bundle.Manifest.DocumentTitle}’…");
 
                 await Task.Run(() =>
                 {
@@ -75,9 +74,6 @@ namespace MonoDevelop.Figma.Commands
                     };
                     bundle.SaveAll(includeImages, fileProvider);
                 });
-
-                IdeApp.Workbench.StatusBar.EndProgress();
-                IdeApp.Workbench.StatusBar.AutoPulse = false;
 
                 await currentFolder.Project.IncludeBundleAsync(bundle, includeImages)
                     .ConfigureAwait(true);

--- a/tools/MonoDevelop.Figma/Commands/RegenerateDocumentCommandHandler.cs
+++ b/tools/MonoDevelop.Figma/Commands/RegenerateDocumentCommandHandler.cs
@@ -75,7 +75,7 @@ namespace MonoDevelop.Figma.Commands
                     bundle.SaveAll(includeImages, fileProvider);
                 });
 
-                await currentFolder.Project.IncludeBundleAsync(bundle, includeImages)
+                await currentFolder.Project.IncludeBundleAsync(monitor, bundle, includeImages)
                     .ConfigureAwait(true);
             }
         }

--- a/tools/MonoDevelop.Figma/Extensions/IdeProgressMonitorManagerExtensions.cs
+++ b/tools/MonoDevelop.Figma/Extensions/IdeProgressMonitorManagerExtensions.cs
@@ -1,0 +1,43 @@
+﻿// Authors:
+//   Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (C) 2021 Microsoft, Corp
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using MonoDevelop.Core;
+using MonoDevelop.Ide.Gui;
+
+namespace MonoDevelop.Figma
+{
+    static class IdeProgressMonitorManagerExtensions
+    {
+        public static ProgressMonitor GetFigmaProgressMonitor(this IdeProgressMonitorManager manager, string title)
+        {
+            return manager.GetStatusProgressMonitor(
+                title,
+                Stock.StatusSolutionOperation,
+                false,
+                false,
+                false,
+                null);
+        }
+    }
+}

--- a/tools/MonoDevelop.Figma/Extensions/ProjectExtensions.cs
+++ b/tools/MonoDevelop.Figma/Extensions/ProjectExtensions.cs
@@ -193,7 +193,7 @@ namespace MonoDevelop.Figma
 
 		public static async Task IncludeBundleAsync (this Project currentProject, FigmaBundle bundle, bool includeImages = false, bool savesInProject = true)
 		{
-			Ide.IdeApp.Workbench.StatusBar.ShowMessage("Including files into current project…");
+			using var monitor = IdeApp.Workbench.ProgressMonitors.GetFigmaProgressMonitor("Including files into current project…");
 
 			var figmaFolder = Path.Combine(currentProject.BaseDirectory.FullPath, FigmaBundle.FigmaDirectoryName);
 			if (!currentProject.PathExistsInProject(figmaFolder))

--- a/tools/MonoDevelop.Figma/Extensions/ProjectExtensions.cs
+++ b/tools/MonoDevelop.Figma/Extensions/ProjectExtensions.cs
@@ -48,7 +48,7 @@ namespace MonoDevelop.Figma
 			var fileProvider = new ControlRemoteNodeProvider() { Version = version };
 			await fileProvider.LoadAsync(figmaBundle.FileId);
 
-			Console.WriteLine($"[Done] Loaded Remote File provider for Version {version?.id ?? "Current"}");
+			FigmaSharp.Services.LoggingService.LogInfo($"[Done] Loaded Remote File provider for Version {version?.id ?? "Current"}");
 			var codeRendererService = new NativeViewCodeService(fileProvider) {
 				TranslationService = new Services.MonoDevelopTranslationService()
 			};

--- a/tools/MonoDevelop.Figma/Extensions/ProjectExtensions.cs
+++ b/tools/MonoDevelop.Figma/Extensions/ProjectExtensions.cs
@@ -42,7 +42,7 @@ namespace MonoDevelop.Figma
 {
     public static class Extensions
 	{
-		public static async Task UpdateFigmaFilesAsync (this Project sender, IEnumerable<ProjectFile> projectFiles, FigmaBundle figmaBundle, FigmaFileVersion version, bool translateStrings)
+		public static async Task UpdateFigmaFilesAsync (this Project sender, ProgressMonitor monitor, IEnumerable<ProjectFile> projectFiles, FigmaBundle figmaBundle, FigmaFileVersion version, bool translateStrings)
         {
 			var includeImages = true;
 			var fileProvider = new ControlRemoteNodeProvider() { Version = version };
@@ -56,7 +56,7 @@ namespace MonoDevelop.Figma
 			await Task.Run(() => {
 				figmaBundle.Update(version, fileProvider, includeImages: includeImages);
 			});
-			await sender.IncludeBundleAsync(figmaBundle, includeImages: includeImages);
+			await sender.IncludeBundleAsync(monitor, figmaBundle, includeImages: includeImages);
 
 			foreach (var designerFile in projectFiles) {
 				if (designerFile.TryGetFigmaNode(fileProvider, out var figmaNode)) {
@@ -191,9 +191,9 @@ namespace MonoDevelop.Figma
 			return bundle;
 		}
 
-		public static async Task IncludeBundleAsync (this Project currentProject, FigmaBundle bundle, bool includeImages = false, bool savesInProject = true)
+		public static async Task IncludeBundleAsync (this Project currentProject, ProgressMonitor monitor, FigmaBundle bundle, bool includeImages = false, bool savesInProject = true)
 		{
-			using var monitor = IdeApp.Workbench.ProgressMonitors.GetFigmaProgressMonitor("Including files into current project…");
+			using var task = monitor.BeginTask("Including files into current project…", 1);
 
 			var figmaFolder = Path.Combine(currentProject.BaseDirectory.FullPath, FigmaBundle.FigmaDirectoryName);
 			if (!currentProject.PathExistsInProject(figmaFolder))

--- a/tools/MonoDevelop.Figma/FigmaRuntime.cs
+++ b/tools/MonoDevelop.Figma/FigmaRuntime.cs
@@ -55,8 +55,7 @@ namespace MonoDevelop.Figma
                     }
                     catch (Exception ex)
                     {
-                        Console.WriteLine(TokenMessage);
-                        Console.WriteLine(ex.ToString());
+                        LoggingService.LogError(TokenMessage, ex);
                     }
                 }
                 return PropertyService.Get<string>(FigmaSetting) ?? string.Empty;
@@ -73,8 +72,7 @@ namespace MonoDevelop.Figma
                     catch (Exception ex)
                     {
                         exception = ex;
-                        Console.WriteLine(TokenMessage);
-                        Console.WriteLine(exception.ToString());
+                        LoggingService.LogError(TokenMessage, ex);
                     }
                 }
 

--- a/tools/MonoDevelop.Figma/MonoDevelop.Figma.csproj
+++ b/tools/MonoDevelop.Figma/MonoDevelop.Figma.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net472</TargetFramework>
     <PackOnBuild>true</PackOnBuild>
     <ReleaseVersion>0.1.1</ReleaseVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Xamarin.Mac" />

--- a/tools/MonoDevelop.Figma/NodeBuilders/BundlerNodeBuilder.cs
+++ b/tools/MonoDevelop.Figma/NodeBuilders/BundlerNodeBuilder.cs
@@ -58,7 +58,7 @@ namespace MonoDevelop.Figma
 						bundle = FigmaBundle.FromDirectoryPath(pr.Path.FullPath);
 					} catch (Exception ex) {
 						//if the bundle is removed by any reason whyle updating
-						Console.WriteLine(ex);
+						LoggingService.LogError("CustomFigmaFundlerNodeBuilder", ex);
 					}
 
 					if (bundle != null && bundle.Manifest != null && !string.IsNullOrEmpty (bundle.Manifest.DocumentTitle)) {

--- a/tools/MonoDevelop.Figma/Services/ExtensionLoggingService.cs
+++ b/tools/MonoDevelop.Figma/Services/ExtensionLoggingService.cs
@@ -1,0 +1,89 @@
+﻿// Authors:
+//   Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (C) 2021 Microsoft, Corp
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using FigmaSharp.Services;
+using MonoDevelop.Core;
+
+namespace MonoDevelop.Figma.Services
+{
+    static class ExtensionLoggingService
+    {
+        static ILogger logger;
+        static readonly HashSet<ProgressMonitor> monitors = new HashSet<ProgressMonitor>();
+
+        public static void Init()
+        {
+            logger = new CustomLogger();
+            FigmaSharp.Services.LoggingService.RegisterDefaultLogger(logger);
+        }
+
+        class CustomLogger : FigmaSharp.Services.ILogger
+        {
+            public void Log(LogLevel level, string message)
+            {
+                lock (monitors)
+                {
+                    foreach (var monitor in monitors)
+                    {
+                        switch (level)
+                        {
+                            case LogLevel.Info:
+                                monitor.Log.WriteLine(message);
+                                break;
+
+                            default:
+                                monitor.Log.WriteLine(string.Format("{0}: {1}", level.ToString().ToUpper(), message));
+                                break;
+                        }
+                    }
+
+                    if (monitors.Count > 0)
+                    {
+                        return;
+                    }
+                }
+
+                MonoDevelop.Core.LoggingService.Log((MonoDevelop.Core.Logging.LogLevel)level, "[FIGMA] " + message);
+            }
+        }
+
+        internal static void AddProgressMonitor(ProgressMonitor monitor)
+        {
+            lock (monitors)
+            {
+                monitors.Add(monitor);
+            }
+        }
+
+        internal static void RemoveProgressMonitor(ProgressMonitor monitor)
+        {
+            lock (monitors)
+            {
+                monitors.Remove(monitor);
+            }
+        }
+    }
+}

--- a/tools/MonoDevelop.Figma/Services/ExtensionLoggingService.cs
+++ b/tools/MonoDevelop.Figma/Services/ExtensionLoggingService.cs
@@ -50,12 +50,15 @@ namespace MonoDevelop.Figma.Services
                     {
                         switch (level)
                         {
-                            case LogLevel.Info:
-                                monitor.Log.WriteLine(message);
+                            case LogLevel.Warn:
+                                monitor.ReportWarning(message);
                                 break;
-
+                            case LogLevel.Error:
+                            case LogLevel.Fatal:
+                                monitor.ReportError(message);
+                                break;
                             default:
-                                monitor.Log.WriteLine(string.Format("{0}: {1}", level.ToString().ToUpper(), message));
+                                monitor.Log.WriteLine(message);
                                 break;
                         }
                     }


### PR DESCRIPTION
 - Use progress monitors in a similar way to how VS Mac supports NuGet packages.
 - Introduced a LoggingService which uses Console.WriteLine by default but allows the VS Mac extension to intercept the logging and show the messages in the Figma Console window.

![image](https://user-images.githubusercontent.com/372361/112358841-9a990700-8cc8-11eb-8394-c9728e898fed.png)
![image](https://user-images.githubusercontent.com/372361/112358807-9371f900-8cc8-11eb-86d5-b53288ace2c8.png)
