### PR TITLE
[Extension] Fix designer file not reformatted on updating

### DIFF
--- a/tools/MonoDevelop.Figma/Extensions/ProjectExtensions.cs
+++ b/tools/MonoDevelop.Figma/Extensions/ProjectExtensions.cs
@@ -65,6 +65,8 @@ namespace MonoDevelop.Figma
 						designerFile.FilePath.ParentDirectory,
 						figmaBundle.Namespace,
 						translateStrings);
+
+					await sender.FormatFileAsync(designerFile.FilePath);
 				}
 			}
 		}


### PR DESCRIPTION
The designer file is re-generated when right clicking the Figma
package folder in Visual Studio for Mac. However it was not being
reformatted after the file generation so would not have the same
formatting as other files in the project.