### PR TITLE
manifest: Store the last modified date of the document

### DIFF
--- a/FigmaSharp.Controls/FigmaSharp.Controls/FigmaPackage/FigmaBundle.cs
+++ b/FigmaSharp.Controls/FigmaSharp.Controls/FigmaPackage/FigmaBundle.cs
@@ -141,6 +141,7 @@ namespace FigmaSharp
 			if (Manifest != null && Document != null) {
 				Manifest.DocumentTitle = Document.name;
 				Manifest.DocumentVersion = Document.version;
+				Manifest.DocumentLastModified = Document.lastModified;
 			}
 
 			if (Version == null) {

--- a/FigmaSharp/FigmaSharp/FigmaPackage/FigmaManifest.cs
+++ b/FigmaSharp/FigmaSharp/FigmaPackage/FigmaManifest.cs
@@ -45,6 +45,9 @@ namespace FigmaSharp
 		[ManifestDescription ("Document Version")]
 		public string DocumentVersion { get; set; }
 
+		[ManifestDescription("Document Last Modified")]
+		public string DocumentLastModified { get; set; }
+
 		[ManifestDescription ("Conversion Date")]
 		public DateTime Date { get; set; }
 


### PR DESCRIPTION
Currently there's no way to check a document is actually the latest we're getting from the remote. Sometimes Figma doesn't sync documents, and by adding this timestamp it will be easier to debug issues.