### PR TITLE
Removes constraints in favour of stackview internal alignment + test

### DIFF
--- a/FigmaSharp/FigmaSharp.Cocoa/PropertyConfigure/CodePropertyConfigure.cs
+++ b/FigmaSharp/FigmaSharp.Cocoa/PropertyConfigure/CodePropertyConfigure.cs
@@ -161,64 +161,69 @@ namespace FigmaSharp.Cocoa.PropertyConfigure
 					var absoluteBoundBoxParent = ((IAbsoluteBoundingBox)(parentNode == null ? currentNode.Node.Parent : currentNode.Node.Parent))
 						.absoluteBoundingBox;
 
-					if (constraints.horizontal.Contains("RIGHT") || constraints.horizontal == "SCALE")
+					if (!parentNode.Node.IsStackView())
 					{
-						var endPosition1 = absoluteBoundingBox.X + absoluteBoundingBox.Width;
-						var endPosition2 = absoluteBoundBoxParent.X + absoluteBoundBoxParent.Width;
-						var value = Math.Max(endPosition1, endPosition2) - Math.Min(endPosition1, endPosition2);
+						if (constraints.horizontal.Contains("RIGHT") || constraints.horizontal == "SCALE")
+						{
+							var endPosition1 = absoluteBoundingBox.X + absoluteBoundingBox.Width;
+							var endPosition2 = absoluteBoundBoxParent.X + absoluteBoundBoxParent.Width;
+							var value = Math.Max(endPosition1, endPosition2) - Math.Min(endPosition1, endPosition2);
 
-						var rightConstraintStringValue = CodeGenerationHelpers.GetRightConstraintEqualToAnchor (
-							currentNode.Name, -value, parentNodeName);
-						builder.WritePropertyEquality(rightConstraintStringValue, nameof(NSLayoutConstraint.Active), true);
+							var rightConstraintStringValue = CodeGenerationHelpers.GetRightConstraintEqualToAnchor(
+								currentNode.Name, -value, parentNodeName);
+							builder.WritePropertyEquality(rightConstraintStringValue, nameof(NSLayoutConstraint.Active), true);
+						}
+
+						if (constraints.horizontal.Contains("LEFT"))
+						{
+							var value2 = absoluteBoundingBox.X - absoluteBoundBoxParent.X;
+							var rightConstraintStringValue = CodeGenerationHelpers.GetLeftConstraintEqualToAnchor(
+							currentNode.Name, value2, parentNodeName);
+							builder.WritePropertyEquality(rightConstraintStringValue, nameof(NSLayoutConstraint.Active), true);
+						}
+
+						if (constraints.vertical.Contains("BOTTOM") || constraints.horizontal == "SCALE")
+						{
+							var endPosition1 = absoluteBoundingBox.Y + absoluteBoundingBox.Height;
+							var endPosition2 = absoluteBoundBoxParent.Y + absoluteBoundBoxParent.Height;
+							var value2 = Math.Max(endPosition1, endPosition2) - Math.Min(endPosition1, endPosition2);
+
+							var rightConstraintStringValue = CodeGenerationHelpers.GetBottomConstraintEqualToAnchor(
+						currentNode.Name, -value2, parentNodeName);
+							builder.WritePropertyEquality(rightConstraintStringValue, nameof(NSLayoutConstraint.Active), true);
+						}
+
+						if (constraints.vertical.Contains("TOP"))
+						{
+							var parentFrameObject = currentNode.Node as FigmaFrame;
+
+							var value = absoluteBoundingBox.Y - absoluteBoundBoxParent.Y;
+
+							var rightConstraintStringValue = CodeGenerationHelpers.GetTopConstraintEqualToAnchor(
+							currentNode.Name, value, parentNodeName);
+							builder.WritePropertyEquality(rightConstraintStringValue, nameof(NSLayoutConstraint.Active), true);
+						}
+
+						if (constraints.horizontal == "CENTER" || constraints.horizontal == "SCALE")
+						{
+							var delta = absoluteBoundingBox.X - absoluteBoundBoxParent.X - absoluteBoundBoxParent.Center.X;
+
+							var rightConstraintStringValue = CodeGenerationHelpers.GetConstraintEqualToAnchor(
+						currentNode.Name, nameof(NSView.LeftAnchor), delta, parentNodeName, nameof(NSView.CenterXAnchor));
+							builder.WritePropertyEquality(rightConstraintStringValue, nameof(NSLayoutConstraint.Active), true);
+						}
+
+						if (constraints.vertical == "CENTER" || constraints.vertical == "SCALE")
+						{
+							var delta = absoluteBoundingBox.Y - absoluteBoundBoxParent.Y - absoluteBoundBoxParent.Center.Y;
+
+							var rightConstraintStringValue = CodeGenerationHelpers.GetConstraintEqualToAnchor(
+					currentNode.Name, nameof(NSView.TopAnchor), delta, parentNodeName, nameof(NSView.CenterYAnchor));
+							builder.WritePropertyEquality(rightConstraintStringValue, nameof(NSLayoutConstraint.Active), true);
+						}
 					}
 
-					if (constraints.horizontal.Contains("LEFT"))
-					{
-						var value2 = absoluteBoundingBox.X - absoluteBoundBoxParent.X;
-						var rightConstraintStringValue = CodeGenerationHelpers.GetLeftConstraintEqualToAnchor(
-						currentNode.Name, value2, parentNodeName);
-						builder.WritePropertyEquality(rightConstraintStringValue, nameof(NSLayoutConstraint.Active), true);
-					}
-
-					if (constraints.vertical.Contains("BOTTOM") || constraints.horizontal == "SCALE")
-					{
-						var endPosition1 = absoluteBoundingBox.Y + absoluteBoundingBox.Height;
-						var endPosition2 = absoluteBoundBoxParent.Y + absoluteBoundBoxParent.Height;
-						var value2 = Math.Max(endPosition1, endPosition2) - Math.Min(endPosition1, endPosition2);
-
-						var rightConstraintStringValue = CodeGenerationHelpers.GetBottomConstraintEqualToAnchor(
-					currentNode.Name, -value2, parentNodeName);
-						builder.WritePropertyEquality(rightConstraintStringValue, nameof(NSLayoutConstraint.Active), true);
-					}
-
-					if (constraints.vertical.Contains("TOP"))
-					{
-						var value = absoluteBoundingBox.Y - absoluteBoundBoxParent.Y;
-
-						var rightConstraintStringValue = CodeGenerationHelpers.GetTopConstraintEqualToAnchor(
-						currentNode.Name, value, parentNodeName);
-						builder.WritePropertyEquality(rightConstraintStringValue, nameof(NSLayoutConstraint.Active), true);
-					}
-
-                    if (constraints.horizontal == "CENTER" || constraints.horizontal == "SCALE")
-                    {
-                        var delta = absoluteBoundingBox.X - absoluteBoundBoxParent.X - absoluteBoundBoxParent.Center.X;
-
-						var rightConstraintStringValue = CodeGenerationHelpers.GetConstraintEqualToAnchor(
-					currentNode.Name, nameof (NSView.LeftAnchor), delta, parentNodeName, nameof(NSView.CenterXAnchor));
-						builder.WritePropertyEquality(rightConstraintStringValue, nameof(NSLayoutConstraint.Active), true);
-                    }
-
-                    if (constraints.vertical == "CENTER" || constraints.vertical == "SCALE")
-                    {
-                        var delta = absoluteBoundingBox.Y - absoluteBoundBoxParent.Y - absoluteBoundBoxParent.Center.Y;
-
-						var rightConstraintStringValue = CodeGenerationHelpers.GetConstraintEqualToAnchor(
-				currentNode.Name, nameof(NSView.TopAnchor), delta, parentNodeName, nameof(NSView.CenterYAnchor));
-						builder.WritePropertyEquality(rightConstraintStringValue, nameof(NSLayoutConstraint.Active), true);
-                    }
-
-                    return builder.ToString();
+					return builder.ToString();
 				}
 				return string.Empty;
 			}

--- a/tests/FigmaSharp.Tests/FigmaSharp.Tests.csproj
+++ b/tests/FigmaSharp.Tests/FigmaSharp.Tests.csproj
@@ -41,6 +41,7 @@
     <Compile Include="Resources.cs" />
     <Compile Include="ToCode\ElipseTests.cs" />
     <Compile Include="ToCode\CocoaStringObjectTests.cs" />
+    <Compile Include="ToCode\CodePropertyConfigureTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="test.json">

--- a/tests/FigmaSharp.Tests/ToCode/CodePropertyConfigureTests.cs
+++ b/tests/FigmaSharp.Tests/ToCode/CodePropertyConfigureTests.cs
@@ -1,0 +1,73 @@
+﻿// Authors:
+//   Jose Medrano <josmed@microsoft.com>
+//
+// Copyright (C) 2018 Microsoft, Corp
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System.Linq;
+
+using NUnit.Framework;
+using FigmaSharp.Cocoa.PropertyConfigure;
+using FigmaSharp.Controls.Cocoa;
+using FigmaSharp.PropertyConfigure;
+using FigmaSharp.Services;
+using System;
+
+namespace FigmaSharp.Tests.ToCode
+{
+    [TestFixture(TestName = "CodePropertyConfigure")]
+    public class CodePropertyConfigureTests : ConvertersTestBase
+    {
+        [Test]
+        public void StackView_Children()
+        {
+            var parentNode = new CodeNode(StackViewHorizontalNode) { Name = "item1" };
+            Assert.NotNull(parentNode.Node);
+            var node = new CodeNode(parentNode.Node.GetChildren().FirstOrDefault()) { Name = "item2" };
+            var addCode = propertyConfigure.ConvertToCode(PropertyNames.AddChild, node, parentNode, null, null);
+            Assert.AreEqual($"item1.AddArrangedSubview (item2);", addCode);
+
+            var constraintsCode = propertyConfigure
+                .ConvertToCode(PropertyNames.Constraints, node, parentNode, null, service)
+                .Split(new [] { "\n" }, StringSplitOptions.RemoveEmptyEntries);
+            Assert.AreEqual(constraintsCode.Length, 0);
+        }
+
+        [Test]
+        public void View_Children()
+        {
+            var parentNode = new CodeNode(StackViewNode) { Name = "item1" };
+            Assert.NotNull(parentNode.Node);
+            var node = new CodeNode(parentNode.Node.GetChildren().FirstOrDefault()) { Name = "item2" };
+
+            var addCode = propertyConfigure.ConvertToCode(PropertyNames.AddChild, node, parentNode, null, null);
+            Assert.AreEqual($"item1.AddSubview (item2);", addCode);
+
+            var constraintsCode = propertyConfigure
+                .ConvertToCode(PropertyNames.Constraints, node, parentNode, null, service)
+                .Split(new[] { "\n" }, StringSplitOptions.RemoveEmptyEntries);
+
+            Assert.AreEqual(constraintsCode.Length, 2);
+            Assert.AreEqual("item2.LeftAnchor.ConstraintEqualToAnchor (item1.LeftAnchor, 19f).Active = true;", constraintsCode[0]);
+            Assert.AreEqual("item2.TopAnchor.ConstraintEqualToAnchor (item1.TopAnchor, 19f).Active = true;", constraintsCode[1]);
+        }
+    }
+}

--- a/tests/FigmaSharp.Tests/ToCode/StackViewTests.cs
+++ b/tests/FigmaSharp.Tests/ToCode/StackViewTests.cs
@@ -37,10 +37,17 @@ using FigmaSharp.Services;
 
 namespace FigmaSharp.Tests.ToCode
 {
-    public class ConvertersTestBase
+	public class ConvertersTestBase
     {
+        protected FigmaNode StackViewNode => provider.FindByName("StackView");
+        protected FigmaNode StackViewHorizontalNode => provider.FindByName("Horizontal");
+        protected FigmaNode StackViewVerticalNode => provider.FindByName("Vertical");
+
         protected Converters.NodeConverter[] converters;
         protected ControlRemoteNodeProvider provider;
+
+        protected CodeRenderService service;
+        protected CodePropertyConfigure propertyConfigure;
 
         [SetUp]
         public void Init()
@@ -49,7 +56,10 @@ namespace FigmaSharp.Tests.ToCode
             converters = FigmaControlsContext.Current.GetConverters(true);
 
             provider = new ControlRemoteNodeProvider();
-            provider.Load("sjjkWQHVrvxVDuQnm7AFMS");
+            provider.Load("6crgoezVRZOEgn5EXOB0Pj");
+
+            propertyConfigure = new CodePropertyConfigure();
+            service = new CodeRenderService(provider, converters, propertyConfigure);
         }
     }
 


### PR DESCRIPTION
When any item is inside a StackView, this view changes and manages how the internal views are going to be stacked, so in this case we need to skip adding any constraints and have the stack view do the work.

Fixes #345 