### PR TITLE
Fix placeholder child views being added to generated code

### DIFF
--- a/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Keywords/PlaceholderKeywordConverter.cs
+++ b/FigmaSharp.Controls/FigmaSharp.Controls.Cocoa/Converters/Keywords/PlaceholderKeywordConverter.cs
@@ -36,7 +36,7 @@ namespace FigmaSharp.Controls.Cocoa.Converters
 	{
 		public override bool ScanChildren(FigmaNode currentNode) => false;
 
-        const string PlaceholderKeyword = "!placeholder";
+        const string PlaceholderKeyword = "placeholder";
 
 		public override bool CanConvert(FigmaNode currentNode) => false;
         public override bool CanCodeConvert(FigmaNode currentNode) => currentNode.GetNodeTypeName() == PlaceholderKeyword;

--- a/tests/FigmaSharp.Tests/FigmaSharp.Tests.csproj
+++ b/tests/FigmaSharp.Tests/FigmaSharp.Tests.csproj
@@ -44,6 +44,7 @@
     <Compile Include="ToCode\CodePropertyConfigureTests.cs" />
     <Compile Include="ToCode\SkipNodeTests.cs" />
     <Compile Include="NSApplicationInitializer.cs" />
+    <Compile Include="ToCode\PlaceholderTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="test.json">

--- a/tests/FigmaSharp.Tests/ToCode/PlaceholderTests.cs
+++ b/tests/FigmaSharp.Tests/ToCode/PlaceholderTests.cs
@@ -1,0 +1,76 @@
+﻿// Authors:
+//   Matt Ward <matt.ward@microsoft.com>
+//
+// Copyright (C) 2021 Microsoft, Corp
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+using System.Text;
+using FigmaSharp.Controls.Cocoa;
+using FigmaSharp.Controls.Cocoa.Services;
+using FigmaSharp.Services;
+using NUnit.Framework;
+
+namespace FigmaSharp.Tests.ToCode
+{
+    [TestFixture]
+    public class PlaceholderTests
+    {
+        Converters.NodeConverter[] converters;
+        ControlRemoteNodeProvider provider;
+
+        [SetUp]
+        public void Init()
+        {
+            NSApplicationInitializer.Initialize();
+            FigmaControlsApplication.Init(Resources.PublicToken);
+            converters = FigmaControlsContext.Current.GetConverters(true);
+
+            provider = new ControlRemoteNodeProvider();
+            provider.Load("oc3h9FQGFDtiRcR5goEnzy");
+        }
+
+        /// <summary>
+        /// Tests child nodes of "!placeholder" nodes are ignored by code generation.
+        /// </summary>
+        [Test]
+        public void PlaceholderChildNodesShouldBeSkippedByCodeGenerator()
+        {
+            var window = provider.FindByName("MyWindow");
+            Assert.NotNull(window);
+
+            var service = new NativeViewCodeService(provider, converters);
+            var options = new CodeRenderServiceOptions()
+            {
+                ShowComments = false,
+                ShowSize = false,
+                ShowConstraints = false
+            };
+
+            var builder = new StringBuilder();
+            service.GetCode(builder, new CodeNode(window), currentRendererOptions: options);
+            string code = builder.ToString();
+
+            StringAssert.DoesNotContain("labelToBeSkipped", code);
+            StringAssert.Contains("placeHolderView", code);
+            StringAssert.Contains("placeHolderView = new AppKit.NSView", code);
+        }
+    }
+}


### PR DESCRIPTION
The custom code converter for the !placeholder item was being
skipped since it was comparing "!placeholder" with the code type
name "placeholder" which has the exclamation character removed.
The custom code converter skips child nodes but it was not being
used.